### PR TITLE
[FIX] ファイル名の指定ミスを修正しSQL文のAI・PK指定を追加、READMEファイルを更新しました

### DIFF
--- a/test_bot_taturon_20200811/README.md
+++ b/test_bot_taturon_20200811/README.md
@@ -1,0 +1,9 @@
+##動作確認の手順
+1. dbConnect.phpのDB名、ユーザー名、パスワードをデータを挿入したいDBのものに置き換える
+2. createRakutenRecipeTable.sqlを用いてDBに「rakuten_recipe」のテーブルを作成する
+3. LINE Developersのダッシュボードへアクセスし、
+トップ>[プロバイダー名]>[アプリ名]>Messaging API設定>Webhook URL
+をプロサーサーバーの動作確認URLに設定する(このファイルと同一フォルダにあるwebhookTest.phpを指定する)
+4. 動作確認用URLでcategoryInsert.phpにアクセスするかCUIのphpコマンドで実行しデータを挿入する
+5. エラーが出なければ挿入成功
+6. 挿入したデータに該当する文字列をLineで送信すると、その入力値で曖昧検索した結果ヒットしたレシピカテゴリIDが楽天レシピカテゴリランキングAPIに送られ、返ってきたレシピタイトルとレシピURLが表示されます。

--- a/test_bot_taturon_20200811/createRakutenRecipeTable.sql
+++ b/test_bot_taturon_20200811/createRakutenRecipeTable.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `rakuten_recipe` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) NOT NULL,
-  `category_id` varchar(20) NOT NULL
+  `category_id` varchar(20) NOT NULL,
+  PRIMARY KEY(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/test_bot_taturon_20200811/readme.txt
+++ b/test_bot_taturon_20200811/readme.txt
@@ -1,8 +1,0 @@
-動作確認の手順
-1.dbConnect.phpのDB名、ユーザー名、パスワードをデータを挿入したいDBのものに置き換える
-2.createRakutenRecipeTable.sqlを用いてDBに「rakuten_recipe」のテーブルを作成する
-3.LINE Developersのダッシュボードへアクセスし、
-トップ>[プロバイダー名]>[アプリ名]>Messaging API設定>Webhook URL
-をプロサーサーバーの動作確認URLに設定する
-4.動作確認用URLでcategoryInsert.phpにアクセスするかCUIのphpコマンドで実行しデータを挿入する
-5.エラーが出なければ挿入成功（ボットの動作確認ができるはずです）

--- a/test_bot_taturon_20200811/webhookTest.php
+++ b/test_bot_taturon_20200811/webhookTest.php
@@ -19,7 +19,7 @@ foreach ($client->parseEvents() as $event) {
 		$message = $event['message'];
 		switch ($message['type']) {
 		case 'text':
-			require_once('recipe_extract.php');
+			require_once('recipeExtract.php');
 			$client->replyMessage([
 				'replyToken' => $event['replyToken'],
 				'messages' => [


### PR DESCRIPTION
# 修正の概要
- webhookTest.phpのrequire_once('recipe_extract.php');をrequire_once('recipeExtract.php')に変更
- createRakutenRecipeTable.sql のidカラムにAI・PK設定を追加
- READMEファイルの更新